### PR TITLE
Allow adding dependencies for rust code

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "highlight.js": "^9.13.1",
     "js-sha1": "^0.6.0",
     "katex": "^0.10.0-beta",
-    "showdown": "^1.8.6"
+    "showdown": "^1.8.6",
+    "yaml": "^1.0.3"
   }
 }

--- a/src/codegen.js
+++ b/src/codegen.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const showdown = require('showdown');
+const yaml = require('yaml');
 
 const Bundle = require('./bundle').Bundle;
 const PluginsManager = require('./plugins-manager');
@@ -11,7 +12,6 @@ class Codegen {
         this.pluginsManager = new PluginsManager();
 
         this.input = options.input.filename;
-        this.metadataConverter = new showdown.Converter({ metadata: true });
     }
 
     run() {
@@ -53,13 +53,13 @@ class Codegen {
     parseMetadata() {
         console.info('parsing metadata');
 
-        this.metadataConverter.makeHtml(`---\n${this.slides[0].content}\n---`);
+        const slidesMeta = yaml.parse(`${this.slides[0].content}`);
 
         const optionsMeta = {
             'options-debug': this.options.debug,
         };
         const metadata = Object.freeze(
-            Object.assign({}, optionsMeta, this.metadataConverter.getMetadata())
+            Object.assign({}, optionsMeta, slidesMeta)
         );
 
         this.slides = this.slides.slice(1);

--- a/src/plugins/rustc/index.js
+++ b/src/plugins/rustc/index.js
@@ -6,7 +6,7 @@ fixWindowsANSIColors(ansi_up);
 
 const CODE_BLOCK_PATTERN = /```rust([\s\S]*?)```/gm;
 const NO_SHOW_PATTERN = /^#(?: .*)?\n/gm;
-const HIDDEN_PATTERN = /^#\s*/gm;
+const HIDDEN_PATTERN = /^#$|#\s+/gm;
 const IGNORE_PATTERN = /^\/\/ *ignore/m;
 const NORUN_PATTERN = /^\/\/ *norun/m;
 const ERROR_PATTERN = /\n\n.*aborting due to/m;


### PR DESCRIPTION
You can now add dependencies for rust code. Dependencies are declared in the metadata header using the `cargo-deps` key. It accepts an array of strings in the same format as in `Cargo.toml`. Example:

```yaml
cargo-deps:
  - crossbeam = "0.5.0"
  - num_cpus = "1.8.0"
```

Internally the `rustc` plugin now creates a `Cargo.toml` file with the specified dependencies and uses `cargo` to download and compile them. Code from code blocks is placed in `src/bin` and compiled with `cargo rustc --bin FILE`.

Additionally this changes the metadata parser to the `yaml` package. This is because `showdown.Converter` doesn't handle yaml arrays properly. As a bonus the `rustc-allows` metadata option should now work.

Known issues:
- the `target` directory is deleted after each run of the tool, so dependencies must be compiled on every run
