### PR TITLE
Limit image width to slide width

### DIFF
--- a/src/plugins/global/dist/global.css
+++ b/src/plugins/global/dist/global.css
@@ -16,6 +16,7 @@ div.slide {
 img {
     display: flex;
     margin: 0 auto;
+    max-width: 100%;
 }
 
 table {


### PR DESCRIPTION
Limit image width so that images don't poke outside the slides.