### PR TITLE
controls: Add gestures on mobile devices

### DIFF
--- a/src/plugins/frontend/dist/controls.css
+++ b/src/plugins/frontend/dist/controls.css
@@ -1,3 +1,8 @@
+body {
+    /* Needed for a bigger gestures-recognition area */
+    min-height: 80vh;
+}
+
 nav {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
**Why was this PR needed?**

When reading lectures from the phone, it's very hard to change the slides due to a lack of <kbd>left</kbd> and <kbd>right</kbd> keys on the standard Android / iPhone keyboard.

**What does this PR do?**

This PR adds event listeners for touch events, binding them to the lecture controls.

**How was this PR tested?**

Manually on:
* Google Pixel XL phone (running Google Chrome on a vanilla Android 10)
* Firefox Developer Edition (72) on Arch Linux

**Are there any changes the maintainers should watch out for?**

The constants for the gestures were pretty much thought-up on the spot. If there is a paper with recommended value, please don't hesitate to update them.

**Are there any known issues?**

There are currently two known issues with this:

 1. Tap-to-zoom changes two slides and zooms.
 2. Simulating a phone view under Firefox Developer Edition 72 does not fire the `touchend` event with coordinates.