### PR TITLE
Remove subslides on ?animations=false

### DIFF
--- a/src/plugins/frontend/dist/controls.js
+++ b/src/plugins/frontend/dist/controls.js
@@ -61,6 +61,27 @@
     }
 
     window.addEventListener('load', () => {
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.get('animations') === 'false') {
+            let slideGroups = [];
+
+            document.body.querySelectorAll('div.slide').forEach(function(slide) {
+                if (slide.classList.contains('subslide')) {
+                    // add it to the currently-tracked group
+                    slideGroups[slideGroups.length - 1].push(slide);
+                } else {
+                    // initialize a new group
+                    slideGroups.push([slide]);
+                }
+            });
+
+            for (let slides of slideGroups) {
+                // only keep the last slide of each group
+                slides.pop();
+                slides.forEach(s => s.remove());
+            }
+        }
+
         const controls = (function() {
             const slides = Array.prototype.slice.call(document.body.querySelectorAll('div.slide'));
             const concreteSlides = slides.filter(slide => !slide.classList.contains('subslide'));


### PR DESCRIPTION
This PR adds the option to remove animations from slides. Opening the URL with `?animations=false` is going to find all subslides of a particular concrete slide and then delete all of them except for the last one. It feels a bit hacky, but it seems to work, at a first glance.

Animations are good when presenting, because people can see things step by step, like code examples and their results, and a bunch of bullet points one by one without being distracted by the later ones. But when reading at home, it's easier to just see the whole slide. So we can link them with `?animations=false` in the site.

Open to any suggestions for name changes and code restructuring.