### PR TITLE
Change rust edition to 2018

### DIFF
--- a/src/plugins/rustc/index.js
+++ b/src/plugins/rustc/index.js
@@ -57,6 +57,7 @@ module.exports = (metadata, utils) => {
         'name = "rust"',
         'version = "0.1.0"',
         'authors = []',
+        'edition = "2018"',
         '',
         '[dependencies]',
     ]


### PR DESCRIPTION
Add `edition = "2018"` when creating Cargo.toml