### PR TITLE
fix(rustc): replace .cargo/config with .cargo/config.toml

### DIFF
--- a/src/plugins/rustc/index.js
+++ b/src/plugins/rustc/index.js
@@ -74,7 +74,7 @@ module.exports = (metadata, utils) => {
         `rustflags = [${warningFlags}]`,
     ].join('\n');
 
-    projectDir.mkdirSync('.cargo').writeFileSync('config', cargoConfig);
+    projectDir.mkdirSync('.cargo').writeFileSync('config.toml', cargoConfig);
 
     const config = {
         typeCheckCmd: 'cargo check',

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,25 +171,9 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
-he@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-
 highlight.js@^9.13.1:
   version "9.13.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
-
-highlight.js@^9.7.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
-
-html-encoder-decoder@^1.3.2:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/html-encoder-decoder/-/html-encoder-decoder-1.3.7.tgz#9e764ab6494dd24a4cea8ccae6e29b17bd10acb2"
-  dependencies:
-    he "^1.1.0"
-    iterate-object "^1.3.2"
-    regex-escape "^3.4.2"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -212,10 +196,6 @@ is-stream@^1.1.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-
-iterate-object@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/iterate-object/-/iterate-object-1.3.2.tgz#24ec15affa5d0039e8839695a21c2cae1f45b66b"
 
 js-sha1@^0.6.0:
   version "0.6.0"
@@ -337,10 +317,6 @@ reduce-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
 
-regex-escape@^3.4.2:
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/regex-escape/-/regex-escape-3.4.8.tgz#d819372b24fb2659174196ecbecfa69d8612f30d"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -363,15 +339,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-showdown-highlight@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/showdown-highlight/-/showdown-highlight-2.1.0.tgz#b973229c645e5d7b2201ad1874b9ef9aae14c16c"
-  dependencies:
-    highlight.js "^9.7.0"
-    html-encoder-decoder "^1.3.2"
-    showdown "^1.4.3"
-
-showdown@^1.4.3, showdown@^1.8.6:
+showdown@^1.8.6:
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.8.6.tgz#91ea4ee3b7a5448aaca6820a4e27e690c6ad771c"
   dependencies:
@@ -482,6 +450,11 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yaml@^1.0.3:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
New cargo versions emit a warning, that `.cargo/config` is deprecated and `.cargo/config.toml` should be used instead. Those warning show in the rendered presentation.