### PR TITLE
fix(plugins): subslide regex includes preceding empty lines

### DIFF
--- a/src/plugins/subslides.js
+++ b/src/plugins/subslides.js
@@ -1,4 +1,4 @@
-const SUBSLIDE_PATTER = /^\s*?--\s*?\n/gm;
+const SUBSLIDE_PATTER = /^[ \t]*--[ \t]*\n/gm;
 
 module.exports = (_, utils) => ({
     extend(slides) {


### PR DESCRIPTION
The regex pattern for subslides (--) incorrectly matches preceding empty lines.

Example text:
```
foo

--
bar
```

Previously it would match `\n--\n`.
Now it matches just `--\n`.

Leaving the empty line intact is important in order for "bar" to be rendered in new paragraph.